### PR TITLE
Use rayon to make check king parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,59 @@
 version = 4
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rust_chess"
 version = "0.1.0"
+dependencies = [
+ "rayon",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+rayon = "1.10"

--- a/src/board_manager.rs
+++ b/src/board_manager.rs
@@ -5,6 +5,7 @@ use crate::pieces::types::move_direction::{
   SpecialMove, SpecialMoveValidationAction,
 };
 use crate::pieces::types::position::Position;
+use rayon::prelude::*;
 use std::collections::HashMap;
 
 pub struct BoardManager {
@@ -46,7 +47,7 @@ impl BoardManager {
   }
 
   fn can_apply_move(
-    &mut self,
+    &self,
     piece_position: Position,
     target_position: Position,
     current_player_color: Color,
@@ -84,7 +85,7 @@ impl BoardManager {
   }
 
   fn validate_move_basics(
-    &mut self,
+    &self,
     piece_position: Position,
     current_player_color: Color,
   ) -> Result<(), String> {
@@ -122,7 +123,7 @@ impl BoardManager {
   }
 
   fn validate_special_move(
-    &mut self,
+    &self,
     action: SpecialMoveValidationAction,
     from: Position,
     to: Position,
@@ -132,7 +133,7 @@ impl BoardManager {
   }
 
   fn validate_piece_exists(
-    &mut self,
+    &self,
     piece_position: Position,
   ) -> Result<(), String> {
     if self.chessboard.is_position_empty(piece_position) {
@@ -143,7 +144,7 @@ impl BoardManager {
   }
 
   fn validate_player_owns_piece(
-    &mut self,
+    &self,
     piece_position: Position,
     current_player_color: Color,
   ) -> Result<(), String> {
@@ -154,32 +155,33 @@ impl BoardManager {
     Ok(())
   }
 
-  fn is_king_checked(&mut self, current_player_color: Color) -> bool {
+  fn is_king_checked(&self, current_player_color: Color) -> bool {
     let enemy_color = current_player_color.next();
-    let king_position = self.chessboard.get_king_position(enemy_color);
+    let king_position = match self.chessboard.get_king_position(enemy_color) {
+      Some(pos) => pos,
+      None => return false,
+    };
 
-    if king_position.is_none() {
-      return false;
-    }
-
-    let king_position = king_position.unwrap();
-
-    for position in self.chessboard.get_all_positions() {
-      if self.chessboard.is_position_empty(position) {
-        continue;
-      }
-      let piece = self.chessboard.get_piece(position).unwrap();
-
-      if piece.is_of_color(current_player_color) {
-        if self
-          .can_apply_move(position, king_position, current_player_color)
-          .is_ok()
-        {
-          return true;
+    self
+      .chessboard
+      .get_all_positions()
+      .par_iter()
+      .filter_map(|&position| {
+        if self.chessboard.is_position_empty(position) {
+          return None;
         }
-      }
-    }
-    false
+        let piece = self.chessboard.get_piece(position)?;
+        if piece.is_of_color(current_player_color) {
+          Some(position)
+        } else {
+          None
+        }
+      })
+      .any(|from| {
+        self
+          .can_apply_move(from, king_position, current_player_color)
+          .is_ok()
+      })
   }
 
   pub fn upgrade_piece(
@@ -217,11 +219,11 @@ impl BoardManager {
   fn get_special_move_validation_action(
     &self,
     special_move_validation: SpecialMoveValidationAction,
-  ) -> Box<dyn Fn(&mut BoardManager, Position, Position) -> bool> {
+  ) -> Box<dyn Fn(&BoardManager, Position, Position) -> bool> {
     let mut special_move_validation_functions = HashMap::new();
     special_move_validation_functions.insert(
       SpecialMoveValidationAction::EnemyPieceExists,
-      |board_manager: &mut BoardManager,
+      |board_manager: &BoardManager,
        piece_position: Position,
        target_position: Position| {
         if board_manager.chessboard.is_position_empty(target_position) {


### PR DESCRIPTION
The goal of this PR is to convert the `is_king_checked` from the sequential pattern to the parallel pattern. I used a modified version of the `test_king_check_after_move` unit test to benchmark the results:
```
  use std::time::Instant;

  #[test]
  fn test_king_check_after_move() {
    use crate::pieces::{King, Rook};

    // Create a function to create the test-specific chessboard
    fn create_test_board() -> ChessboardType {
      let mut custom_board: ChessboardType = from_fn(|_| from_fn(|_| None));

      // Place black king at E8 (row 7, col 4)
      custom_board[7][4] = Some(Box::new(King::new(Color::Black)));

      // Place white rook at E1 (row 0, col 4)
      custom_board[0][4] = Some(Box::new(Rook::new(Color::White)));

      custom_board
    }

    // Number of iterations to run the test
    let iterations = 1000000;
    let mut total_duration = std::time::Duration::new(0, 0);

    for _ in 0..iterations {
      // Start measuring time
      let start = Instant::now();

      // Initialize the board only once
      let custom_board = create_test_board();

      let mut board_manager = BoardManager::new(Chessboard::new(
        custom_board,
        Vec::new(),
        Vec::new(),
      ));

      // Move rook from E1 to E7 (just before the king), to put the king in check
      let result = board_manager.move_piece(
        Position::new(0, 4).unwrap(), // E1
        Position::new(6, 4).unwrap(), // E7
        Color::White,
      );

      // Check that the result is a check
      assert!(matches!(result, Ok(MoveResult::CheckKing))); // Should result in check

      // Stop measuring time and accumulate the duration
      let duration = start.elapsed();
      total_duration += duration;
    }

    // Calculate average duration
    let avg_duration = total_duration / iterations as u32;

    // Print the average execution time
    println!(
      "Average test execution time over {} iterations: {:?}",
      iterations, avg_duration
    );
  }
  
  ```
  
  The results were confusing:
  w/o parallism:
  ```
cargo test tests::board_manager_tests::tests::test_king_check_after_move -- --nocapture
   Compiling rust_chess v0.1.0 (/Users/yassa/rust_projects/rust_chess)
    Finished test profile [unoptimized + debuginfo] target(s) in 0.30s
     Running unittests src/main.rs (target/debug/deps/rust_chess-efc89d86d161ec1f)

running 1 test
Average test execution time over 1000000 iterations: 5.88µs
test tests::board_manager_tests::tests::test_king_check_after_move ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 38 filtered out; finished in 6.12s
  ```
  with parallism:
  ```
  cargo test tests::board_manager_tests::tests::test_king_check_after_move -- --nocapture
   Compiling rust_chess v0.1.0 (/Users/yassa/rust_projects/rust_chess)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.31s
     Running unittests src/main.rs (target/debug/deps/rust_chess-5aa81009f06dfaef)

running 1 test
Average test execution time over 100000 iterations: 41.662µs
test tests::board_manager_tests::tests::test_king_check_after_move ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 38 filtered out; finished in 4.17s
  ```
  
  Conclusion:
  The sequential code was 7-times faster than the parallel code:
 Sequential: Average test execution time over 1000000 iterations: 5.88µs.
 Parallel: Average test execution time over 100000 iterations: 41.662µs